### PR TITLE
Mise à jour fonctions postUpdate() et MAJVehicules()

### DIFF
--- a/core/class/prixcarburants.class.php
+++ b/core/class/prixcarburants.class.php
@@ -130,35 +130,27 @@ class prixcarburants extends eqLogic {
 
 			log::add('prixcarburants','debug',' step count selection '.count($maselection).' '.$nom);
 
-			if ($station1 == '') {
+			if ($station1 != '') $nbstation = 1; //If a favorite is selected, only 1 station need to be fill
 				
-				usort($maselection, "prixcarburants::custom_sort");
-				
-				For($i = 1; $i <= $nbstation; $i++) {
-					$macmd = cmd::byEqLogicIdCmdName($unvehicule->getId(),'Top ' . $i . ' ID');
-					if (is_object($macmd)) $macmd->event($maselection[$i - 1]['id']);
-					
-					$macmd = cmd::byEqLogicIdCmdName($unvehicule->getId(),'Top ' . $i . ' Adresse');
-					if (is_object($macmd)) $macmd->event($maselection[$i - 1]['adresse']);
-					
-					$macmd = cmd::byEqLogicIdCmdName($unvehicule->getId(),'Top ' . $i . ' MAJ');
-					if (is_object($macmd)) $macmd->event($maselection[$i - 1]['maj']);
-					
-					$macmd = cmd::byEqLogicIdCmdName($unvehicule->getId(),'Top ' . $i . ' Prix');
-					if (is_object($macmd)) $macmd->event($maselection[$i - 1]['prix']);
-				}
-			}else{ // enmode station favoris
-				$macmd = cmd::byEqLogicIdCmdName($unvehicule->getId(),'Top 1 ID');
-				if (is_object($macmd)) $macmd->event($maselection[0]['id']);
-				
-				$macmd = cmd::byEqLogicIdCmdName($unvehicule->getId(),'Top 1 Adresse');
-				if (is_object($macmd)) $macmd->event($maselection[0]['adresse']);
-				
-				$macmd = cmd::byEqLogicIdCmdName($unvehicule->getId(),'Top 1 MAJ');
-				if (is_object($macmd)) $macmd->event($maselection[0]['maj']);
-				
-				$macmd = cmd::byEqLogicIdCmdName($unvehicule->getId(),'Top 1 Prix');
-				if (is_object($macmd)) $macmd->event($maselection[0]['prix']);
+			usort($maselection, "prixcarburants::custom_sort");
+			
+			For($i = 1; $i <= $nbstation; $i++) {
+			    if($maselection[$i - 1]['prix'] != ''){ //Price available so, there is enough station on selected range
+    				$macmd = cmd::byEqLogicIdCmdName($unvehicule->getId(),'Top ' . $i . ' ID');
+    				if (is_object($macmd)) $macmd->event($maselection[$i - 1]['id']);
+    				
+    				$macmd = cmd::byEqLogicIdCmdName($unvehicule->getId(),'Top ' . $i . ' Adresse');
+    				if (is_object($macmd)) $macmd->event($maselection[$i - 1]['adresse']);
+    				
+    				$macmd = cmd::byEqLogicIdCmdName($unvehicule->getId(),'Top ' . $i . ' MAJ');
+    				if (is_object($macmd)) $macmd->event($maselection[$i - 1]['maj']);
+    				
+    				$macmd = cmd::byEqLogicIdCmdName($unvehicule->getId(),'Top ' . $i . ' Prix');
+    				if (is_object($macmd)) $macmd->event($maselection[$i - 1]['prix']);
+			    } else {
+			        $macmd = cmd::byEqLogicIdCmdName($unvehicule->getId(),'Top ' . $i . ' Adresse');
+			        if (is_object($macmd)) $macmd->event('{{Plus de station disponible dans le rayon sélectionné}}');
+			    }
 			}
 			
 			$unvehicule->refreshWidget();

--- a/core/class/prixcarburants.class.php
+++ b/core/class/prixcarburants.class.php
@@ -213,9 +213,7 @@ class prixcarburants extends eqLogic {
 
 	public function preInsert() {}
 
-	public function postInsert() {
-		//$mynewcolis = new prixcarburants();
-	}
+	public function postInsert() {}
 
 	public function preSave() {}
 
@@ -227,7 +225,7 @@ class prixcarburants extends eqLogic {
 		if (!is_object($PrixCarburantsCmd)) {
 			log::add('prixcarburants', 'debug', 'refresh');
 			$PrixCarburantsCmd = new prixcarburantsCmd();
-			$PrixCarburantsCmd->setName(__('Rafraîchir', __FILE__));
+			$PrixCarburantsCmd->setName('{{Rafraichir}}');
 			$PrixCarburantsCmd->setEqLogic_id($this->getId());
 			$PrixCarburantsCmd->setLogicalId('refresh');
 			$PrixCarburantsCmd->setType('action');
@@ -239,12 +237,32 @@ class prixcarburants extends eqLogic {
 	public function preUpdate() {}
 
 	public function postUpdate() {
-		$nbstation = $this->getConfiguration('nbstation','3');
+		//Choose correct quantity of station. Only 1 if there is a favorite selected
+		$FavorisMode = $this->getConfiguration('station1','');
+		if($FavorisMode == ''){
+		    $nbstation = $this->getConfiguration('nbstation','3');
+		} else {
+		    $nbstation = 1;
+		}
 		
 		$OrdreAffichage = 1;
 		
 		For($i = 1; $i <= 10; $i++) {
-			if($i <= $nbstation) { //Show only required quantity of station
+		    //Remove all station to avoid having too much station when favorite is selected
+		    $prixcarburantsCmd = cmd::byEqLogicIdCmdName($this->getId(),'Top ' . $i . ' ID');
+		    if (is_object($prixcarburantsCmd)) $prixcarburantsCmd->remove();
+		    
+		    $prixcarburantsCmd = cmd::byEqLogicIdCmdName($this->getId(),'Top ' . $i . ' Adresse');
+		    if (is_object($prixcarburantsCmd)) $prixcarburantsCmd->remove();
+		    
+		    $prixcarburantsCmd = cmd::byEqLogicIdCmdName($this->getId(),'Top ' . $i . ' MAJ');
+		    if (is_object($prixcarburantsCmd)) $prixcarburantsCmd->remove();
+		    
+		    $prixcarburantsCmd = cmd::byEqLogicIdCmdName($this->getId(),'Top ' . $i . ' Prix');
+		    if (is_object($prixcarburantsCmd)) $prixcarburantsCmd->remove();
+		    
+		    //Show only required quantity of station
+			if($i <= $nbstation) {
 				$prixcarburantsCmd = $this->getCmd(null, 'TopID_'.$i);
 				if (!is_object($prixcarburantsCmd)) $prixcarburantsCmd = new prixcarburantsCmd();
 				$prixcarburantsCmd->setName('Top ' . $i . ' ID');
@@ -302,18 +320,6 @@ class prixcarburants extends eqLogic {
 				$prixcarburantsCmd->setOrder($OrdreAffichage);
 				$prixcarburantsCmd->save();
 				$OrdreAffichage++;
-			} else { //remove undesired station
-				$prixcarburantsCmd = $this->getCmd(null, 'TopAdresse_'.$i);
-				if (is_object($prixcarburantsCmd)) $prixcarburantsCmd->remove();
-				
-				$prixcarburantsCmd = $this->getCmd(null, 'TopPrix_'.$i);
-				if (is_object($prixcarburantsCmd)) $prixcarburantsCmd->remove();
-				
-				$prixcarburantsCmd = $this->getCmd(null, 'TopMaJ_'.$i);
-				if (is_object($prixcarburantsCmd)) $prixcarburantsCmd->remove();
-				
-				$prixcarburantsCmd = $this->getCmd(null, 'TopID_'.$i);
-				if (is_object($prixcarburantsCmd)) $prixcarburantsCmd->remove();
 			}
 		}
 		

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -8,5 +8,8 @@
 - mettre en avant une confiance par rapport à la date de dernière mise à jour.
 
 
+## 11 juin 2020
+- Mise à jour de la fonctionnalité de sélection du nombre de station à surveiller, qui ne fonctionnait pas quand l'équipement était créé avant la mise à jour précédente
+
 ## 10 juin 2020
 - Ajout de la possibilité de choisir le nombre de station surveillée, jusqu'à 10 maximum

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -10,6 +10,7 @@
 
 ## 11 juin 2020
 - Mise à jour de la fonctionnalité de sélection du nombre de station à surveiller, qui ne fonctionnait pas quand l'équipement était créé avant la mise à jour précédente
+- Ajout d'un message quand le nombre de station surveillé à supérieur au nombre de station disponible dans le rayon sélectionné
 
 ## 10 juin 2020
 - Ajout de la possibilité de choisir le nombre de station surveillée, jusqu'à 10 maximum

--- a/docs/fr_FR/changelog.md
+++ b/docs/fr_FR/changelog.md
@@ -1,0 +1,12 @@
+# Changelog : Prix Carburants
+
+### TODO list
+- Créer une documentation
+- Améliorer la sélection de la station favoris (au lieu d'afficher le fichier JSON brut)
+- Pouvoir sur un seul véhicule avoir le choix entre suivre une station favorite et des stations autour des coordonnées
+- se servir du plugin geotrav pour obtenir les coordonées (prendre exemple sur le plugin DarkSky ?)
+- mettre en avant une confiance par rapport à la date de dernière mise à jour.
+
+
+## 10 juin 2020
+- Ajout de la possibilité de choisir le nombre de station surveillée, jusqu'à 10 maximum


### PR DESCRIPTION
## 1 : fonction postUpdate (lignes 243 à 257)
La fonction permettant de choisir le nombre de station à surveiller était défaillante si le véhicule avait été créé avant la mise à jour du plugin. Cela renvoyait [https://community.jeedom.com/t/projet-en-cours-prix-carburants/23547/32](ce défaut).

Le problème venait de la méthode de sélection des commandes existantes, basé sur le "LogicalId", alors qu'ils n'étaient pas clairement défini précédemment. Désormais, la sélection se fait sur la base du "Name".

## 2 : fonction postUpdate (lignes 232 à 238)
Ajout du nombre maximum de station à surveiller à 1, quand une station favorite a été inscrite.

## 3 : fonction MAJVehicules (lignes 133 à 161 de l'ancien code)
Suppression de la redondance des lignes de code remplissant les données.
En effet, il y avait 2 fois le même code, si c'était pour 1 station favorite, ou pour plusieurs stations.
J'ai donc, défini le nombre de station à 1, quand c'est un favori, puis cela passe dans la même boucle que plusieurs stations.

## 4 : fonction MAJVehicules (lignes 137 & 150 à 153)
Ajout d'un message lorsque le nombre de station à surveiller est plus grand que le nombre de station disponible dans le rayon sélectionné.

## 4 : fonction postInsert (ligne 217)
Suppression de la ligne commentée dans postInsert