### PR TITLE
Fix PHP Warning

### DIFF
--- a/core/class/prixcarburants.class.php
+++ b/core/class/prixcarburants.class.php
@@ -210,7 +210,7 @@ class prixcarburants extends eqLogic {
 			usort($maselection, "prixcarburants::custom_sort");
 			if($unvehicule->getConfiguration('OrdreFavoris','Ordre') == "Prix") usort($SelectionFav, "prixcarburants::custom_sort");
           
-          	$lreservoir = $unvehicule->getConfiguration('reservoirlitre');
+          	$lreservoir = $unvehicule->getConfiguration('reservoirlitre', 0);
 			
 			//Register favorites then require quantity of station from localisation
 			$nbstation = $NbFavoris + $nbstation;


### PR DESCRIPTION
A non-numeric value encountered in /var/www/html/plugins/prixcarburants/core/class/prixcarburants.class.php on line 237

Due to no value in "Capacité du réservoir (litres)" field :
![image](https://user-images.githubusercontent.com/8396512/149625258-b2976ded-a997-4188-907a-b667a83f24fe.png)
