### PR TITLE
Add Cmd geoloc + auto update + coord dispo

### DIFF
--- a/core/class/prixcarburants.class.php
+++ b/core/class/prixcarburants.class.php
@@ -56,7 +56,18 @@ class prixcarburants extends eqLogic {
 	        return __('Erreur',  __FILE__);
 	    }
 	}
+	// ========== Manage listener update
+  public static function trigger($_option) {
+		log::add(__CLASS__, 'debug', '╔═══════════════════════  Trigger sur id :'.$_option['id']);
 
+		$eqLogic = self::byId($_option['id']);
+		if (is_object($eqLogic) && $eqLogic->getIsEnable() == 1) {
+          	self::MAJVehicules($eqLogic);
+			//$eqLogic->checkCondition();
+		}
+      log::add(__CLASS__,'debug', "╚═════════════════════════════════════════ END Trigger ");
+		
+	}
 	//Function list all gaz station that correspond to defined parameters on the configuration
 	public static function MAJVehicules($oneveh) {
 		
@@ -105,14 +116,15 @@ class prixcarburants extends eqLogic {
         			    $macmd = cmd::byEqLogicIdCmdName($unvehicule->getId(),'Top 1 Adresse');
         			    if (is_object($macmd)) $macmd->event(__('Pas de localisation sélectionnée',  __FILE__));
         			    return;
-        			} elseif ($unvehicule->getConfiguration('geoloc') == "jeedom") {
+        			} elseif ($unvehicule->getConfiguration('jeedom_loc') == 1) {
         			    $malat = config::byKey('info::latitude');
         			    $malng = config::byKey('info::longitude');
         			} else {
-        			    if (geotravCmd::byEqLogicIdAndLogicalId($unvehicule->getConfiguration('geoloc'),'location:coordinate') != null){
-                            $coordonnees = geotravCmd::byEqLogicIdAndLogicalId($unvehicule->getConfiguration('geoloc'),'location:coordinate')->execCmd();
+                      $cmd=cmd::byId(str_replace('#','',$unvehicule->getConfiguration('geoloc')));
+        			    if ($cmd!= null){
+                            $coordonnees = $cmd->execCmd();
         			    } else {
-        			        $coordonnees = cmd::byId($unvehicule->getConfiguration('geoloc'))->execCmd();
+        			        log::add(__CLASS__,'error',__('commande de localisation non trouvée ',  __FILE__).$nom);
         			    }
         			    $expcoord = explode(",",$coordonnees);
         		        $malat = $expcoord[0];
@@ -181,6 +193,8 @@ class prixcarburants extends eqLogic {
 							    $SelectionFav[$ordreFav]['maj']  = date($monformatdate, strtotime($maj));
 							    $SelectionFav[$ordreFav]['distance'] = $dist;
 							    $SelectionFav[$ordreFav]['id'] = $mastationid;
+                               	$SelectionFav[$ordreFav]['coord'] = $lat .",". $lng;
+                              
 							} else { //Register station that are one the radius
 							    $maselection[$idx]['adresse'] = $marque.', '.$unestation->ville;
 							    $maselection[$idx]['prix'] = $prixlitre;
@@ -189,7 +203,8 @@ class prixcarburants extends eqLogic {
                               
 							    $maselection[$idx]['distance'] = $dist;
 							    $maselection[$idx]['id'] = $mastationid;
-                              
+                              	$maselection[$idx]['coord'] = $lat .",". $lng;
+                              	
                               	if ($style != '') $maselection[$idx]['maj'] = $style . $maselection[$idx]['maj'] . '</div>';
                               	
                               
@@ -215,6 +230,7 @@ class prixcarburants extends eqLogic {
 			//Register favorites then require quantity of station from localisation
 			$nbstation = $NbFavoris + $nbstation;
 			For($i = 1; $i <= $nbstation; $i++) {
+              	
 			    if($i <= $NbFavoris) {
 			        $liste[$i - 1] = $SelectionFav[$i - 1];
 			    } else {
@@ -238,7 +254,10 @@ class prixcarburants extends eqLogic {
 
                     $macmd = cmd::byEqLogicIdCmdName($unvehicule->getId(),'Top ' . $i.' Distance');
                     if (is_object($macmd)) $macmd->event($liste[$i - 1]['distance']);
-
+                  
+                  $macmd = cmd::byEqLogicIdCmdName($unvehicule->getId(),'Top ' . $i.' Coord');
+                    if (is_object($macmd)) $macmd->event($liste[$i - 1]['coord']);
+					
                   
 			    } else {
 			        $macmd = cmd::byEqLogicIdCmdName($unvehicule->getId(),'Top ' . $i . ' Adresse');
@@ -263,6 +282,10 @@ class prixcarburants extends eqLogic {
 
                     $macmd = cmd::byEqLogicIdCmdName($unvehicule->getId(),'Top ' . $i.' Prix Plein');
                     if (is_object($macmd)) $macmd->event('');
+                  
+                  $macmd = cmd::byEqLogicIdCmdName($unvehicule->getId(),'Top ' . $i.' Coord');
+                    if (is_object($macmd)) $macmd->event($liste[$i - 1]['coord']);
+
                   
 			    }
 			}
@@ -329,6 +352,73 @@ class prixcarburants extends eqLogic {
 		//Create file with fuel price if it doesn't exist (first creation)
 		if (!file_exists(__DIR__.'/PrixCarburants_instantane.xml')) {
 		  $prixcarburantsCmd->getEqLogic()->updatePrixCarburant();
+		}
+      
+      	// manage listener if needed
+       $this->setListener();
+	}
+  // Listener manager function
+   private function getListener() {
+		return listener::byClassAndFunction(__CLASS__, 'trigger', array('id' => $this->getId()));
+	}
+  private function removeListener() {
+      log::add(__CLASS__, 'debug', ' Suppression des Ecouteurs de '.$this->getHumanName());
+		$listener = $this->getListener();
+		if (is_object($listener)) {
+			$listener->remove();
+		}
+	}
+  
+  private function setListener() {
+		log::add(__CLASS__, 'debug', ' Recording listeners');
+
+		$glCmd = $this->getConfiguration('geoloc', '');
+      
+      	log::add(__CLASS__, 'debug', 'Geoloc command : '.$glCmd);
+
+		if ($this->getIsEnable() == 0 || $glCmd==='' || !$this->getConfiguration('ViaLoca', false) || !$this->getConfiguration('auto_update', false) ) {
+			$this->removeListener();
+			return;
+		}
+
+		$pregResult = preg_match_all("/#([0-9]*)#/", $glCmd, $matches);
+      
+		if ($pregResult===false) {
+			log::add(__CLASS__, 'error', __('Erreur regExp Expression', __FILE__) . ': '.  $expression);
+			$this->removeListener();
+			return;
+		}
+
+		if ($pregResult<1) {
+			log::add(__CLASS__, 'debug', 'Pas de Commandes trouvés dans les listeners');
+			$this->removeListener();
+			return;
+		}
+
+		$listener = $this->getListener();
+		if (!is_object($listener)) {
+          	
+			$listener = new listener();
+			$listener->setClass(__CLASS__);
+			$listener->setFunction('trigger');
+			$listener->setOption(array('id' => $this->getId()));
+		}
+		$listener->emptyEvent();
+
+		$eventAdded = false;
+		foreach ($matches[1] as $cmd_id) {
+			if (!is_numeric($cmd_id)) continue;
+          
+			$cmd = cmd::byId($cmd_id);
+          log::add(__CLASS__, 'debug', 'Ajout listener pour la commande :'.$cmd->getHumanName());
+			if (!is_object($cmd)) continue;
+			$listener->addEvent($cmd->getId());
+			$eventAdded = true;
+		}
+		if ($eventAdded) {
+			$listener->save();
+		} else {
+			$listener->remove();
 		}
 	}
 
@@ -447,6 +537,24 @@ class prixcarburants extends eqLogic {
                 $prixcarburantsCmd->save();
                 $OrdreAffichage++;
               
+              $prixcarburantsCmd = $this->getCmd(null, 'Coord_'.$i);
+                if (!is_object($prixcarburantsCmd)) $prixcarburantsCmd = new prixcarburantsCmd();
+                $prixcarburantsCmd->setName('Top ' . $i.' Coord');
+                $prixcarburantsCmd->setEqLogic_id($this->getId());
+                $prixcarburantsCmd->setLogicalId('Coord_'.$i);
+                $prixcarburantsCmd->setType('info');
+                $prixcarburantsCmd->setSubType('other');
+                $prixcarburantsCmd->setIsHistorized(0);
+                $prixcarburantsCmd->setIsVisible(0);
+                $prixcarburantsCmd->setDisplay('showNameOndashboard',0);
+                $prixcarburantsCmd->setTemplate('dashboard','badge');
+                $prixcarburantsCmd->setTemplate('mobile','badge');
+                $prixcarburantsCmd->setOrder($OrdreAffichage);
+                $prixcarburantsCmd->save();
+                $OrdreAffichage++;
+              
+              
+              
               
 			} else {
 			    //Remove all station to avoid having too much station when favorite is selected
@@ -467,13 +575,18 @@ class prixcarburants extends eqLogic {
 
                 $prixcarburantsCmd = cmd::byEqLogicIdCmdName($this->getId(),'Top ' . $i.' Distance');
                 if (is_object($prixcarburantsCmd)) $prixcarburantsCmd->remove();
+              
+              	$prixcarburantsCmd = cmd::byEqLogicIdCmdName($this->getId(),'Top ' . $i.' Coord');
+                if (is_object($prixcarburantsCmd)) $prixcarburantsCmd->remove();
 			}
 		}
 		
 		prixcarburants::MAJVehicules($this);
 	}
 
-	public function preRemove() {}
+	public function preRemove() {
+        $this->removeListener();
+    }
 
 	public function postRemove() {}
 }

--- a/desktop/js/prixcarburants.js
+++ b/desktop/js/prixcarburants.js
@@ -234,11 +234,15 @@ function CheckBx(Type_) {
   
 	if(Type_ == "ViaLoca+") {
 		document.getElementById('Divloca1').style.display = "block";
+      document.getElementById('Divloca1Auto').style.display = "block";
+      document.getElementById('Divloca1Jeedom').style.display = "block";
 		document.getElementById('Divloca2').style.display = "block";
 		document.getElementById('Divloca3').style.display = "block";
     }
     if(Type_ == "ViaLoca-") {
 		document.getElementById('Divloca1').style.display = "none";
+      document.getElementById('Divloca1Auto').style.display = "none";
+      document.getElementById('Divloca1Jeedom').style.display = "none";
 		document.getElementById('Divloca2').style.display = "none";
 		document.getElementById('Divloca3').style.display = "none";
 		document.getElementById('rayon').value = "";
@@ -330,4 +334,14 @@ $('.eqLogicAttr[data-l1key=configuration][data-l2key=Favoris]').change(function(
 	} else {
 		CheckBx('Favoris-');
 	}
+});
+
+$(".cmdSendSel").on('click', function () {
+   
+ var el = $(this);
+  jeedom.cmd.getSelectModal({cmd:{type:'info'}}, function(result) {
+       var calcul = el.closest('div').find('.eqLogicAttr[data-l1key=configuration][data-l2key=geoloc]');
+       calcul.val('');
+       calcul.atCaret('insert', result.human);
+     });
 });

--- a/desktop/php/prixcarburants.php
+++ b/desktop/php/prixcarburants.php
@@ -160,42 +160,21 @@ $eqLogics = eqLogic::byType($plugin->getId());
     								<div class="form-group" id="Divloca1" style="display: none;">
         								<label class="Conteneur_Label" for="geoloc">{{Chercher autour de :}}</label>
         								<div class="Conteneur_Input">
-                                            <select class="eqLogicAttr form-control" id="geoloc" data-l1key="configuration" data-l2key="geoloc">
-                                                <?php
-                                                $none = 0;
-                                                if (class_exists('geotravCmd')) {
-                                                    //List all geotrav localisation
-                                                    foreach (eqLogic::byType('geotrav') as $geoloc) {
-                                                        if ($geoloc->getConfiguration('type') == 'location' && $geoloc->getConfiguration('coordinate') != '') {
-                                                            $none++;
-                                                            echo '<option value="' . $geoloc->getId() . '">' . $geoloc->getName() . '</option>';
-                                                        }
-                                                    }
-                                                    //List all geoloc localisation
-                                                    foreach (eqLogic::byType('geoloc') as $moneqGeoLoc) {
-                                                        if ($moneqGeoLoc->getIsEnable()){
-                                                            foreach (cmd::searchConfigurationEqLogic($moneqGeoLoc->getId(),'{"mode":"fixe"') as $geoloc) {
-                                                                $none++;
-                                                                echo '<option value="' . $geoloc->getId() . '">' . $geoloc->getName() . '</option>';
-                                                            }
-                                                            foreach (cmd::searchConfigurationEqLogic($moneqGeoLoc->getId(),'{"mode":"dynamic"') as $geoloc) {
-                                                                $none++;
-                                                                echo '<option value="' . $geoloc->getId() . '">' . $geoloc->getName() . '</option>';
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                                if ((config::byKey('info::latitude') != '') && (config::byKey('info::longitude') != '') ) {
-                                                    echo '<option value="jeedom">{{Configuration Jeedom}}</option>';
-                                                    $none++;
-                                                }
-                                                if ($none == 0) {
-                                                    echo '<option value="none">{{Pas de localisation disponible (latitude et longitude nécessaire)}}</option>';
-                                                }
-                                                ?>
-                                            </select>
+                                             <input class="eqLogicAttr form-control CTA-cmd-el" data-l1key="configuration" data-l2key="geoloc" style="display:inline-block; width:90%"/> 
+                                                   <span class="input-group-btn" style="display:inline-block; width:auto"> 
+                                                   <button type="button" class="btn btn-default cursor listCmdActionMessage tooltips cmdSendSel" title="{{Rechercher une commande}}" data-input="sendCmd"><i class="fas fa-list-alt"></i></button> 
+                                                   </span> 
                                         </div>
+                                       
         							</div>
+                                     <div class="form-group" id="Divloca1Auto" style="display: none;">
+                                        	<label class="Conteneur_Label">{{Mise à jour auto :}}</label>
+                                            <input id="auto_update" type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="auto_update" />
+                                        </div>
+                                       <div class="form-group" id="Divloca1Jeedom" style="display: none;">
+                                        	<label class="Conteneur_Label">{{Utiliser la localisation jeedom :}}</label>
+                                            <input id="jeedom_loc" type="checkbox" class="eqLogicAttr" data-l1key="configuration" data-l2key="jeedom_loc" />
+                                        </div>
         							
                                     <div class="form-group" id="Divloca2" style="display: none;">
         								<label class="Conteneur_Label" for="rayon">{{Rayon maxi (Km) :}}</label>

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -18,13 +18,46 @@
 
 require_once dirname(__FILE__) . '/../../../core/php/core.inc.php';
 
-function template_install() {
-    
+function prixcarburants_install() {
+  log::add('prixcarburants','debug', '======= installation de '.$eqLogic->getHumanName());
+  
 }
 
-function template_update() {
-        //Message to be display after update. TO be remove for next plugin updates
-        message::add('Modification configuration plugin PrixCarburants', 'Suite à une grosse refont de la configuration du plugin PrixCarburants, merci d\'ouvrir la configuration de chaque équipement pour re-définir correctement vos besoins');
+function prixcarburants_update() {
+  $plugin = plugin::byId('prixcarburants');
+  foreach (eqLogic::byType($plugin->getId()) as $eqLogic) {
+      log::add('prixcarburants','debug', '!!======= mise à jour de '.$eqLogic->getHumanName());
+      
+      
+      // geoloc parameter to fit previous config
+      $geoloc = $eqLogic->getConfiguration('geoloc', 'none');
+      log::add('prixcarburants','debug', 'current geoloc :'.$geoloc);
+
+  		if($geoloc == 'jeedom'){// si jeedom 
+        	$eqLogic->setConfiguration('jeedom_loc', true);
+          $eqLogic->setConfiguration('geoloc', null);
+          $eqLogic->setConfiguration('auto_update', false);
+          log::add('prixcarburants','debug', 'ajout de la localisation jeedom ');
+          
+        }elseif(is_numeric($geoloc) && !is_null($geoloc)){// si cmd id
+          $eqLogic->setConfiguration('jeedom_loc', false);
+          $locationcmd = cmd::byEqLogicIdAndLogicalId($geoloc, 'location:coordinate');
+          if(!is_object($locationcmd)){
+            log::add('prixcarburants','debug', 'essai commande localisation par ID');
+            $locationcmd = cmd::byId($geoloc);
+          }
+          if(is_object($locationcmd)){
+           $eqLogic->setConfiguration('geoloc', "#". $locationcmd->getId()."#");
+           $eqLogic->setConfiguration('auto_update', false);
+            log::add('prixcarburants','debug', 'transformation de la commande localisation : '.$locationcmd->getHumanName());
+          }else{
+            log::add('prixcarburants','debug', 'commande localisation non trouvée');
+          }
+          
+        }
+		$eqLogic->save();
+ }
+ log::add('prixcarburants','debug','=============  fin de mise à jour');
 
 }
 


### PR DESCRIPTION
Salut floman,

J'ai pas mal foiré avec l'appli desktop, du coup je refait un PR plus propre (par rappor au #15 )

_____________________________________

Je propose ce PR pour passer d'une commande d'un plugin de geolocalisation fixe à n'importe quelle commande qui fournis les coordonnées longitude/latitude (par exemple gls ou jeedoconnect, autre virtuel), et dont la mise à jour déclenche la mise à jour du calcul sur les meilleures stations.

ce qui

    transforme le champs select vers une selection de commande type info avec une modale du core
    ajoute une case à cocher pour mettre en place un écouteur sur la commande renseignée qui lance la mise à jour avec les nouvelle coordonnées
    ajoute une case à cocher pour utiliser les coordonnées jeedom
    j'ai ajoutée la commande info coord pour chaque top qui référence les coordonnées des station en top (histoire de pouvoir les utiliser directement au besoin)

Le script d'install permet de modifier les valeurs de configuration de geoloc pour les transformer dans l'utilisation faites ici.

Je n'ai pas testé les favoris, ça foire en 4.2.x

il manque un peu de js pour masquer les champs de selection si coordonnées jeedom choisi.

a ta dispo pour toute question/modifs
