### PR TITLE
Limit the number of empty stations displayed

### DIFF
--- a/core/class/prixcarburants.class.php
+++ b/core/class/prixcarburants.class.php
@@ -872,18 +872,32 @@ class prixcarburants extends eqLogic
 		$GazStation_template = getTemplate('core', $version, 'gazstation.template', 'prixcarburants');
 		$GazStation_Qtty = 0;
 
+		$EmptyStation = 0;
 		for ($i = 1; $i <= 20; $i++) {
-			//$TopAdresse_i = $this->getCmd(null, 'TopAdresse_'.$i);
 			if (is_object($this->getCmd(null, 'TopAdresse_' . $i))) {
+				$arr['prix']='';
+			  $arr['logo']='';
+			  $arr['maj']='';
 				$TopAdresse = $this->getCmd(null, 'TopAdresse_' . $i);
 				$replace['#TopMarque#'] = is_object($TopAdresse) ? explode(",", $TopAdresse->execCmd())[0] : '';
 				$replace['#TopVille#'] = is_object($TopAdresse) ? explode(",", $TopAdresse->execCmd())[1] : '';
+				if($replace['#TopMarque#'] == __('Plus de station disponible dans le rayon sélectionné', __FILE__)) $EmptyStation++;
 
 				$PrixStation = $this->getCmd(null, 'TopPrix_' . $i);
-				$replace['#TopPrix#'] = is_object($PrixStation) ? $PrixStation->execCmd() : '';
+				if(is_object($PrixStation)) {
+					$replace['#TopPrix#'] = $PrixStation->execCmd() != '' ? '<a style="font-weight: bold;">'.$PrixStation->execCmd().'</a> €/l' : '';
+				} else {
+					$replace['#TopPrix#'] = '';
+				}
+				
 
-				$DateRecover = $this->getCmd(null, 'TopMaJ_' . $i);
-				$replace['#TopMaJ#'] = is_object($DateRecover) ? __('le ', __FILE__) . $DateRecover->execCmd() : '';
+				$MajStation = $this->getCmd(null, 'TopMaJ_' . $i);
+				if(is_object($MajStation)) {
+					$replace['#TopMaJ#'] = $MajStation->execCmd() != '' ? __('le ', __FILE__) . $MajStation->execCmd() : '';
+				} else {
+					$replace['#TopMaJ#'] = '';
+				}
+				
 
 				if ($template == "default") {
 					$LogoStation = $this->getCmd(null, 'TopLogo_' . $i);
@@ -892,8 +906,10 @@ class prixcarburants extends eqLogic
 					$replace['#LogoStation#'] = ' ';
 				}
 
-				$GazStation_html .= template_replace($replace, $GazStation_template);
-				$GazStation_Qtty++;
+				if($EmptyStation <= 1) {
+					$GazStation_html .= template_replace($replace, $GazStation_template);
+					$GazStation_Qtty++;
+				}
 			}
 		}
 

--- a/core/template/dashboard/gazstation.template.html
+++ b/core/template/dashboard/gazstation.template.html
@@ -3,7 +3,7 @@
             #LogoStation#
         </div>
         <div style="float: right; width: 60px; line-height: 60px; font-size: 14px; margin-right: 5px;">
-            <a style="font-weight: bold;">#TopPrix#</a> €/l
+            #TopPrix#
         </div>
         <div style="margin-left: #TextMargin#px; width: 350px; font-size: 12px; position: relative; top: 50%; -ms-transform: translateY(-50%);
         -webkit-transform: translateY(-50%); transform: translateY(-50%);">

--- a/core/template/mobile/gazstation.template.html
+++ b/core/template/mobile/gazstation.template.html
@@ -3,7 +3,7 @@
         #LogoStation#
     </div>
     <div style="margin-left: #TextMargin#px; width: 350px; font-size: 12px; position: relative;">
-        <a style="font-weight: bold;">#TopPrix#</a> €/l<br />
+        #TopPrix#<br />
         #TopMarque#
     </div>
     <div style="margin-left: 5px; position: absolute;">


### PR DESCRIPTION
Quand il n'y a plus de station disponible dans le rayon sélectionné, n'affiche désormais qu'une seule fois le message d'alerte.
Aussi, retrait des message "le" and "€/l" dans ces cas là.